### PR TITLE
Prioritized inference + updated namespace

### DIFF
--- a/relquant/pp.R
+++ b/relquant/pp.R
@@ -100,7 +100,11 @@ message("   + Inference of parsimonious protein set")
 msnid <- infer_parsimonious_accessions(msnid)
 
 message("   + Compute protein coverage")
-msnid <- compute_protein_coverage(msnid, path_to_FASTA = fasta_file)
+suppressMessages(
+  fst <- Biostrings::readAAStringSet(fasta_file)
+)
+names(fst) <- sub("^(\\S*)\\s.*", "\\1", names(fst))
+msnid <- compute_accession_coverage(msnid, fst)
 
 message("- Prepare reporter ion intensities")
 message("   + Read MASIC ouput")
@@ -124,7 +128,7 @@ rii_peptide <- make_rii_peptide_gl(msnid = msnid,
                                    org_name = "Rattus norvegicus")
 
 message("- Create Ratio Results")
-ratio_results <- make_results_ratio_gl(msnid =  msnid, 
+results_ratio <- make_results_ratio_gl(msnid =  msnid, 
                                        masic_data = masic_data, 
                                        fractions = fractions, 
                                        samples = samples, 
@@ -143,7 +147,7 @@ write.table(rii_peptide,
             row.names = FALSE,
             quote = FALSE)
 
-write.table(ratio_results,
+write.table(results_ratio,
             file = paste(plexedpiper_output_folder, "results_ratio.txt", sep="/"),
             sep="\t",
             row.names = FALSE,

--- a/relquant/pp_ptm.R
+++ b/relquant/pp_ptm.R
@@ -6,7 +6,7 @@
 # -i data/test_phospho/phrp_output/ \
 # -a data/test_phospho/ascore_output/ \
 # -j data/test_phospho/masic_output/ \
-# -g /path/to/global/results_ratio.txt \
+# -g data/test_global/plexedpiper_output/ \
 # -f data/ID_007275_FB1B42E8.fasta \
 # -s data/test_phospho/study_design/ \
 # -o data/test_phospho/plexedpiper_output/
@@ -34,8 +34,8 @@ option_list <- list(
               help="AScore output folder", metavar="character"),
   make_option(c("-j", "--masic_output_folder"), type="character", default=NULL, 
               help="MASIC output folder", metavar="character"),
-  make_option(c("-g", "--global_results_ratio"), type="character", default=NULL, 
-              help="Global results ratio", metavar="character"),
+  make_option(c("-g", "--plexedpiper_global_output_folder"), type="character", default=NULL, 
+              help="PlexedPiper global output folder", metavar="character"),
   make_option(c("-f", "--fasta_file"), type="character", default=NULL, 
               help="FASTA file (RefSeq format)", metavar="character"),
   make_option(c("-s", "--study_design_folder"), type="character", default=NULL, 
@@ -51,7 +51,7 @@ if (is.null(opt$proteomics) |
     is.null(opt$msgf_output_folder) | 
     is.null(opt$ascore_output_folder) | 
     is.null(opt$masic_output_folder) | 
-    is.null(opt$global_results_ratio) | 
+    is.null(opt$plexedpiper_global_output_folder) | 
     is.null(opt$fasta_file) |
     is.null(opt$study_design_folder) |
     is.null(opt$plexedpiper_output_folder)
@@ -64,7 +64,7 @@ proteomics <- tolower(opt$proteomics)
 msgf_output_folder <- opt$msgf_output_folder 
 ascore_output_folder <- opt$ascore_output_folder 
 masic_output_folder <- opt$masic_output_folder 
-global_results_ratio <- opt$global_results_ratio
+plexedpiper_global_output_folder <- opt$plexedpiper_global_output_folder
 fasta_file<- opt$fasta_file
 study_design_folder<- opt$study_design_folder
 plexedpiper_output_folder<- opt$plexedpiper_output_folder
@@ -139,9 +139,9 @@ message("   + Assessing non-inferable proteins")
 msnid <- assess_noninferable_proteins(msnid)
 
 message("   + Inference of parsimonius set")
-results_ratio <- read.table(global_results_ratio,
+global_results_ratio <- read.table(file = paste(plexedpiper_global_output_folder, "results_ratio.txt", sep="/"),
                             header=T, sep="\t")
-global_proteins <- unique(results_ratio$protein_id)
+global_proteins <- unique(global_results_ratio$protein_id)
 
 msnid <- infer_parsimonious_accessions(msnid,
                                        prior=global_proteins)

--- a/relquant/pp_ptm.R
+++ b/relquant/pp_ptm.R
@@ -6,7 +6,7 @@
 # -i data/test_phospho/phrp_output/ \
 # -a data/test_phospho/ascore_output/ \
 # -j data/test_phospho/masic_output/ \
-# -g data/test_global/plexedpiper_output/ \
+# -g data/test_global/plexedpiper_output/results_ratio.txt \
 # -f data/ID_007275_FB1B42E8.fasta \
 # -s data/test_phospho/study_design/ \
 # -o data/test_phospho/plexedpiper_output/
@@ -34,8 +34,8 @@ option_list <- list(
               help="AScore output folder", metavar="character"),
   make_option(c("-j", "--masic_output_folder"), type="character", default=NULL, 
               help="MASIC output folder", metavar="character"),
-  make_option(c("-g", "--plexedpiper_global_output_folder"), type="character", default=NULL, 
-              help="PlexedPiper global output folder", metavar="character"),
+  make_option(c("-g", "--plexedpiper_global_results_ratio"), type="character", default=NULL, 
+              help="PlexedPiper global results ratio table", metavar="character"),
   make_option(c("-f", "--fasta_file"), type="character", default=NULL, 
               help="FASTA file (RefSeq format)", metavar="character"),
   make_option(c("-s", "--study_design_folder"), type="character", default=NULL, 
@@ -51,7 +51,7 @@ if (is.null(opt$proteomics) |
     is.null(opt$msgf_output_folder) | 
     is.null(opt$ascore_output_folder) | 
     is.null(opt$masic_output_folder) | 
-    is.null(opt$plexedpiper_global_output_folder) | 
+    # is.null(opt$plexedpiper_global_results_ratio) | 
     is.null(opt$fasta_file) |
     is.null(opt$study_design_folder) |
     is.null(opt$plexedpiper_output_folder)
@@ -64,7 +64,7 @@ proteomics <- tolower(opt$proteomics)
 msgf_output_folder <- opt$msgf_output_folder 
 ascore_output_folder <- opt$ascore_output_folder 
 masic_output_folder <- opt$masic_output_folder 
-plexedpiper_global_output_folder <- opt$plexedpiper_global_output_folder
+plexedpiper_global_results_ratio <- opt$plexedpiper_global_results_ratio
 fasta_file<- opt$fasta_file
 study_design_folder<- opt$study_design_folder
 plexedpiper_output_folder<- opt$plexedpiper_output_folder
@@ -139,12 +139,14 @@ message("   + Assessing non-inferable proteins")
 msnid <- assess_noninferable_proteins(msnid)
 
 message("   + Inference of parsimonius set")
-global_results_ratio <- read.table(file = paste(plexedpiper_global_output_folder, "results_ratio.txt", sep="/"),
-                            header=T, sep="\t")
-global_proteins <- unique(global_results_ratio$protein_id)
 
-msnid <- infer_parsimonious_accessions(msnid,
-                                       prior=global_proteins)
+if (is.null(plexedpiper_global_results_ratio)) {
+  msnid <- infer_parsimonious_accessions(msnid)
+} else {
+  global_results_ratio <- read.table(plexedpiper_global_results_ratio, header=T, sep="\t")
+  global_protein_ids <- unique(global_results_ratio$protein_id)
+  msnid <- infer_parsimonious_accessions(msnid, prior=global_protein_ids)
+}
 
 message("   + Mapping sites to protein sequence")
 suppressMessages(

--- a/relquant/pp_ptm.R
+++ b/relquant/pp_ptm.R
@@ -156,14 +156,14 @@ if(proteomics == "ph") {
   msnid <- map_mod_sites(msnid, 
                          fst, 
                          accession_col = "accession", 
-                         peptide_mod_col = "Peptide", 
+                         peptide_mod_col = "peptide", 
                          mod_char = "*",
                          site_delimiter = "lower")
 } else if (proteomics %in% c("ac", "ub")) {
   msnid <- map_mod_sites(msnid, 
                          fst, 
                          accession_col = "accession", 
-                         peptide_mod_col = "Peptide", 
+                         peptide_mod_col = "peptide", 
                          mod_char = "#",
                          site_delimiter = "lower")
 } else {
@@ -172,7 +172,7 @@ if(proteomics == "ph") {
 
 
 message("   + Map flanking sequences")
-msnid <- map_flanking_sequences(msnid, fst)
+msnid <- extract_sequence_window(msnid, fst)
 
 message("- Prepare reporter ion intensities")
 message("   + Read MASIC ouput")

--- a/relquant/relquant_acetyl.sh
+++ b/relquant/relquant_acetyl.sh
@@ -3,7 +3,7 @@
 Rscript /relquant/pp_acetyl.R \
 -i /data/test_acetyl/phrp_output \
 -j /data/test_acetyl/masic_output \
--g /data/test_global/plexedpiper_output \
+-g /data/test_global/plexedpiper_output/results_ratio.txt \
 -f /data/ID_007275_FB1B42E8.fasta \
 -s /relquant/study_design_acetyl \
 -o /data/test_acetyl/plexedpiper_output

--- a/relquant/relquant_acetyl.sh
+++ b/relquant/relquant_acetyl.sh
@@ -3,6 +3,7 @@
 Rscript /relquant/pp_acetyl.R \
 -i /data/test_acetyl/phrp_output \
 -j /data/test_acetyl/masic_output \
+-g /data/test_global/plexedpiper_output \
 -f /data/ID_007275_FB1B42E8.fasta \
 -s /relquant/study_design_acetyl \
 -o /data/test_acetyl/plexedpiper_output

--- a/relquant/relquant_phospho.sh
+++ b/relquant/relquant_phospho.sh
@@ -4,6 +4,7 @@ Rscript /relquant/pp_phospho.R \
 -i /data/test_phospho/phrp_output \
 -a /data/test_phospho/ascore_output \
 -j /data/test_phospho/masic_output \
+-g /data/test_global/plexedpiper_output \
 -f /data/ID_007275_FB1B42E8.fasta \
 -s /relquant/study_design_phospho \
 -o /data/test_phospho/plexedpiper_output

--- a/relquant/relquant_phospho.sh
+++ b/relquant/relquant_phospho.sh
@@ -4,7 +4,7 @@ Rscript /relquant/pp_phospho.R \
 -i /data/test_phospho/phrp_output \
 -a /data/test_phospho/ascore_output \
 -j /data/test_phospho/masic_output \
--g /data/test_global/plexedpiper_output \
+-g /data/test_global/plexedpiper_output/results_ratio.txt \
 -f /data/ID_007275_FB1B42E8.fasta \
 -s /relquant/study_design_phospho \
 -o /data/test_phospho/plexedpiper_output

--- a/relquant/relquant_ubiq.sh
+++ b/relquant/relquant_ubiq.sh
@@ -3,7 +3,7 @@
 Rscript /relquant/pp_ubiq.R \
 -i /data/test_ubiq/phrp_output \
 -j /data/test_ubiq/masic_output \
--g /data/test_global/plexedpiper_output \
+-g /data/test_global/plexedpiper_output/results_ratio.txt \
 -f /data/ID_007275_FB1B42E8.fasta \
 -s /relquant/study_design_ubiq \
 -o /data/test_ubiq/plexedpiper_output

--- a/relquant/relquant_ubiq.sh
+++ b/relquant/relquant_ubiq.sh
@@ -3,6 +3,7 @@
 Rscript /relquant/pp_ubiq.R \
 -i /data/test_ubiq/phrp_output \
 -j /data/test_ubiq/masic_output \
+-g /data/test_global/plexedpiper_output \
 -f /data/ID_007275_FB1B42E8.fasta \
 -s /relquant/study_design_ubiq \
 -o /data/test_ubiq/plexedpiper_output


### PR DESCRIPTION
1. Changed names of some functions
  - `PlexedPiper::map_flanking_sequences` ---> `MSnID::extract_sequence_window`
  - `PlexedPiper::compute_protein_coverage` ---> `MSnID::compute_accession_coverage`

2. Added prioritized inference support
  - New flag `-g` that points to the global output folder
  - `infer_parsimonious_accessions` in `pp_ptm.R` takes a new argument containing a list of global proteins