### PR TITLE
Refactor/run plexedpiper

### DIFF
--- a/relquant/motrpac_pipeline.R
+++ b/relquant/motrpac_pipeline.R
@@ -1,17 +1,23 @@
-
-#' @param msnid (MSnID) MSGF+ results
-#' @param path_to_fasta (character) Path and fasta file name
-#' @param masic_data (data.frame) Masic results
-#' @param ascore (data.frame) AScore results
+#' @title Run PlexedPiper
+#'
+#' @description Provide outputs from MSGF+, MASIC, ASCORE (if PTM), 
+#' plus other parameters including fasta sequence db, species, annotation, 
+#' and it returns both the Reported Ion Intensity (RII) and ratio results
+#' @param msgf_output_folder (MSnID) Path to MSGF+ results folder
+#' @param fasta_file (character) Path and fasta file name
+#' @param masic_output_folder (data.frame) Masic results folder
+#' @param ascore_output_folder (data.frame) AScore result folder
 #' @param proteomics (character) One of the following: 
-#' @param study_design (list) The 3 study design datasets as a list
+#' @param study_design_folder (list) Study design folder
 #' @param species (character) Scientific name of a specie (e.g. `Rattus norvegicus`, `Homo sapiens`)
 #' @param annotation (character) Source for annotations: either `RefSeq` or `Uniprot`
 #' @param global_results (character) Only for PTM experiments. 
 #' Ratio results from a global protein abundance experiment. 
 #' If provided, it will infer parsimonious set of accessions. 
 #' Default is `NULL`
-#' @param output_folder (character) Output folder name to save results
+#' @param write_results_to_file (logical) if `TRUE`, write the results to files
+#' @param output_folder (character) Output folder name to save results. 
+#' (if not provided it will save it to the current directory)
 #' @param file_prefix (character) Prefix for the file name outputs
 #' @param save_env (logical) If `TRUE` it saves the R environment to the output folder
 #' @param return_results (logical) If `TRUE` return both ratio and rii results (default `FALSE`)
@@ -21,44 +27,66 @@
 #' @importFrom PlexedPiper read_study_design filter_masic_data
 #' make_rii_peptide_gl make_results_ratio_gl make_rii_peptide_ph
 #' make_results_ratio_ph
-#' @examples
-#' out <- motrpac_pnnl_pipeline(msnid, path_to_fasta, masic_data, ascore=NULL,
-#'                              proteomics = "pr",
-#'                              study_design,
-#'                              species = "Rattus norvegicus",
-#'                              annotation = "RefSeq")
-#' save_pnnl_pipeline_results(out, output_folder = "./global/output/")
-#' 
-#' out <- motrpac_pnnl_pipeline(msnid, path_to_fasta, masic_data, ascore,
-#'                              proteomics = "ph",
-#'                              study_design,
-#'                              species = "Rattus norvegicus",
-#'                              annotation = "RefSeq")
-#' save_pnnl_pipeline_results(out, output_folder = "./phospho/output/")
-
+#' @examples \dontrun{
+#' results <- run_pp(msgf_output_folder = msgf_output_folder,
+#'                   fasta_file  = fasta_file,
+#'                   masic_output_folder = masic_output_folder,
+#'                   ascore_output_folder = ascore_output_folder,
+#'                   proteomics = tolower(proteomics),
+#'                   study_design_folder = study_design_folder,
+#'                   species = species,
+#'                   annotation = annotation,
+#'                   global_results = plexedpiper_global_results_ratio,
+#'                   output_folder = plexedpiper_output_folder,
+#'                   file_prefix = plexedpiper_output_name_prefix,
+#'                   return_results = TRUE,
+#'                   verbose = TRUE)
+#' }
 #' @export
-motrpac_pnnl_pipeline <- function(msnid, 
-                                  path_to_fasta, 
-                                  masic_data,
-                                  ascore = NULL, 
-                                  proteomics,
-                                  study_design, 
-                                  species, 
-                                  annotation,
-                                  global_results = NULL, 
-                                  output_folder = ".",
-                                  file_prefix, 
-                                  save_env = FALSE,
-                                  return_results = FALSE,
-                                  verbose = TRUE) {
+run_plexedpiper <- function(msgf_output_folder, 
+                            fasta_file, 
+                            masic_output_folder,
+                            ascore_output_folder = NULL, 
+                            proteomics,
+                            study_design_folder, 
+                            species, 
+                            annotation,
+                            file_prefix = NULL,
+                            global_results = NULL, 
+                            write_results_to_file = TRUE,
+                            output_folder = NULL,
+                            save_env = FALSE,
+                            return_results = FALSE,
+                            verbose = TRUE) {
+                                  
+  if( is.null(write_results_to_file) & is.null(return_results) ){
+    stop("\nProvide either <write_results_to_file = TRUE> or <return_results = TRUE> or both. Both cannot be FALSE.")
+  }
+  
   if (verbose) {
-    message("- Running MoTrPAC PNNL pipeline with the following parameters:")
+    message("Running PlexedPiper (the MSGF+ pipeline wrapper), with the following parameters:")
     message("- Proteomics experiment:\"", proteomics, "\"")
     message("- Species: \"", species, "\"")
     message("- Annotation: \"", annotation, "\"")
   }
+
+  if(is.null(file_prefix)){
+    file_prefix <- paste0("MSGFPLUS_", toupper(proteomics))  
+    if(!is.null(global_results)){
+      file_prefix <- paste0(file_prefix,"-ip")
+    }
+  }
   
-  fst <- Biostrings::readAAStringSet(path_to_fasta)
+  # Data loading
+  message("- Fetch study design tables")
+  
+  study_design <- read_study_design(study_design_folder)
+  msnid <- read_msgf_data(msgf_output_folder)
+  if(!is.null(ascore_output_folder)) ascore <- read_AScore_results(ascore_output_folder)
+  masic_data <- read_masic_data(masic_output_folder, 
+                                interference_score = TRUE)
+  
+  fst <- Biostrings::readAAStringSet(fasta_file)
   names(fst) <- sub("^(\\S*)\\s.*", "\\1", names(fst))
   
   if (verbose) message("- Filtering MS-GF+ results.")
@@ -88,7 +116,7 @@ motrpac_pnnl_pipeline <- function(msnid,
   
   if (proteomics == "pr") {
     if (verbose) message("   + Protein-level FDR filter")
-    msnid <- compute_num_peptides_per_1000aa(msnid, path_to_FASTA = path_to_fasta)
+    msnid <- compute_num_peptides_per_1000aa(msnid, path_to_FASTA = fasta_file)
     
     msnid <- filter_msgf_data(msnid, level = "accession", fdr.max = 0.01)
   }
@@ -109,7 +137,7 @@ motrpac_pnnl_pipeline <- function(msnid,
     if(verbose) message("     > Reference global proteomics dataset NOT provided")
     prior <- character(0)
   } else {
-    global_ratios <- read.table(global_results, header=T, sep="\t")
+    global_ratios <- read.table(global_results, header=TRUE, sep="\t")
     prior <- unique(global_ratios$protein_id)
   }
   
@@ -163,28 +191,39 @@ motrpac_pnnl_pipeline <- function(msnid,
   
   if (verbose) message("- Saving results.")
   
-  if (!is.null(output_folder)) {
-    if (!dir.exists(file.path(output_folder))) {
-      dir.create(file.path(output_folder), recursive = TRUE)
-    }
-    
-    filename = paste0(file_prefix, "-results_RII-peptide.txt")
-    write.table(rii_peptide,
-                file      = file.path(output_folder, filename),
-                sep       = "\t",
-                row.names = FALSE,
-                quote     = FALSE)
-    
-    filename = paste0(file_prefix, "-results_ratio.txt")
-    write.table(results_ratio,
-                file      = file.path(output_folder, filename),
-                sep       = "\t",
-                row.names = FALSE,
-                quote     = FALSE)
-    if (save_env) {
-      save.image(file = file.path(output_folder, "env.RData"))
+  if(is.null(output_folder)){
+    output_folder <- getwd()
+  }
+  
+  if(write_results_to_file){
+    if (!is.null(output_folder)) {
+      if (!dir.exists(file.path(output_folder))) {
+        dir.create(file.path(output_folder), recursive = TRUE)
+      }
+      
+      filename = paste0(file_prefix, "-results_RII-peptide.txt")
+      write.table(rii_peptide,
+                  file      = file.path(output_folder, filename),
+                  sep       = "\t",
+                  row.names = FALSE,
+                  quote     = FALSE)
+      if(verbose) message("- RII file save to ", file.path(output_folder, filename))
+      
+      filename = paste0(file_prefix, "-results_ratio.txt")
+      write.table(results_ratio,
+                  file      = file.path(output_folder, filename),
+                  sep       = "\t",
+                  row.names = FALSE,
+                  quote     = FALSE)
+      if(verbose) message("- RATIO file save to ", file.path(output_folder, filename))
     }
   }
+  if (save_env) {
+    fileenv = paste0(file_prefix, "-env.RData")
+    save.image(file = file.path(output_folder, fileenv))
+    if(verbose) message("- R environment saved to ", file.path(output_folder, fileenv))
+  }
+
   if (verbose) message("Done!")
   
   if(return_results){

--- a/relquant/pp.R
+++ b/relquant/pp.R
@@ -33,15 +33,6 @@ option_list <- list(
               help="PlexedPiper output folder (Crosstabs)", metavar="character")
 )
 
-get_date <- function(){
-  # GET QC_DATE----
-  date2print <- Sys.time()
-  date2print <- gsub("-", "", date2print)
-  date2print <- gsub(" ", "_", date2print)
-  date2print <- gsub(":", "", date2print)
-  return(date2print)
-}
-
 opt_parser <- OptionParser(option_list = option_list)
 opt <- parse_args(opt_parser)
 
@@ -60,7 +51,7 @@ if (is.null(opt$proteomics) |
 
 # Let's make easy debugging
 study_design_folder <- opt$study_design_folder
-plexedpiper_output_name_prefix <- opt$plexedpiper_output_name_prefix
+pp_output_name_prefix <- opt$pp_output_name_prefix
 study_design_folder <- opt$study_design_folder
 msgf_output_folder <- opt$msgf_output_folder
 ascore_output_folder <- opt$ascore_output_folder
@@ -71,42 +62,42 @@ plexedpiper_global_results_ratio <- opt$plexedpiper_global_results_ratio
 plexedpiper_output_folder <- opt$plexedpiper_output_folder
 fasta_file <- opt$fasta_file
 
+get_date <- function(){
+  date2print <- Sys.time()
+  date2print <- gsub("-", "", date2print)
+  date2print <- gsub(" ", "_", date2print)
+  date2print <- gsub(":", "", date2print)
+  return(date2print)
+}
+
 date2print <- get_date()
-if(is.null(plexedpiper_output_name_prefix)){
-  plexedpiper_output_name_prefix <- paste0("MSGFPLUS_", toupper(proteomics),"-", date2print)  
+if(is.null(pp_output_name_prefix)){
+  pp_output_name_prefix <- paste0("MSGFPLUS_", toupper(proteomics),"-", date2print)  
 }else{
-  plexedpiper_output_name_prefix <- paste0(plexedpiper_output_name_prefix, "-", date2print)
+  pp_output_name_prefix <- paste0(pp_output_name_prefix, "-", date2print)
 }
 
 if(!is.null(plexedpiper_global_results_ratio)){
-  plexedpiper_output_name_prefix <- paste0(plexedpiper_output_name_prefix,"-ip")
+  pp_output_name_prefix <- paste0(pp_output_name_prefix,"-ip")
 }
-
-# Data loading
-message("- Fetch study design tables")
-study_design <- read_study_design(study_design_folder)
-msnid <- read_msgf_data(msgf_output_folder)
-if(!is.null(ascore_output_folder)) ascore <- read_AScore_results(ascore_output_folder)
-masic_data <- read_masic_data(masic_output_folder, 
-                              interference_score = TRUE)
 
 # Pipeline call
 source("~/github/MoTrPAC/motrpac-proteomics-pnnl-prototype/relquant/motrpac_pipeline.R")
-motrpac_pnnl_pipeline(msnid          = msnid,
-                             path_to_fasta  = fasta_file,
-                             masic_data     = masic_data,
-                             ascore         = ascore,
-                             proteomics     = tolower(proteomics),
-                             study_design   = study_design,
-                             species        = species,
-                             annotation     = annotation,
-                             global_results = plexedpiper_global_results_ratio,
-                             output_folder  = plexedpiper_output_folder,
-                             file_prefix    = plexedpiper_output_name_prefix,
-                             save_env       = FALSE,
-                             return_results = FALSE,
-                             verbose        = FALSE)
+results <- run_plexedpiper(msgf_output_folder = msgf_output_folder,
+                           fasta_file  = fasta_file,
+                           masic_output_folder = masic_output_folder,
+                           ascore_output_folder = ascore_output_folder,
+                           proteomics = tolower(proteomics),
+                           study_design_folder = study_design_folder,
+                           species = species,
+                           annotation = annotation,
+                           global_results = plexedpiper_global_results_ratio,
+                           output_folder = plexedpiper_output_folder,
+                           file_prefix = pp_output_name_prefix,
+                           write_results_to_file = TRUE,
+                           save_env = TRUE,
+                           return_results = TRUE,
+                           verbose = TRUE)
+
 
 unlink(".Rcache", recursive=TRUE)
-
-


### PR DESCRIPTION
Rename the function `motrpac_pnnl_pipeline` to `run_pp` in preparation to the integration in the `PlexedPiper` package.

- Extend documentation
- All the PlexedPiper functions run in `pp.R` are now run by this function
- Change the arguments to take folders instead of data pre-processed
- Return the data and/or write it to files or both. At least one of them must be selected by the user
- Take care of dealing with the `file_prefix` if not provided by the user

Update the script `pp.R` accordingly 