### PR TITLE
Update combine_study_design.R

### DIFF
--- a/combine_study_design.R
+++ b/combine_study_design.R
@@ -4,7 +4,6 @@ suppressPackageStartupMessages(suppressWarnings(library(optparse)))
 suppressPackageStartupMessages(suppressWarnings(library(purrr)))
 suppressPackageStartupMessages(suppressWarnings(library(dplyr)))
 suppressPackageStartupMessages(suppressWarnings(library(PlexedPiper)))
-suppressPackageStartupMessages(suppressWarnings(library(stringr)))
 
 option_list <- list(
   make_option(c("-a", "--p1a"),
@@ -64,7 +63,8 @@ study_design <- map(names(study_design), function(name_i) {
         # This can handle references that are combinations of multiple channels
         across(any_of("Reference"), function(ref) {
           map_chr(ref, function(ref_i) {
-            getParseData(parse(text = ref_i)) %>%
+            parse(text = ref_i, keep.source = TRUE) %>%
+              getParseData() %>%
               filter(terminal) %>%
               mutate(text = ifelse(token == "SYMBOL",
                                    paste0(text, "_", PASS),

--- a/combine_study_design.R
+++ b/combine_study_design.R
@@ -62,12 +62,12 @@ study_design <- map(names(study_design), function(name_i) {
                ~ ifelse(is.na(.x), NA, paste0(.x, "_", PASS))),
         # This can handle references that are combinations of multiple channels
         across(any_of("Reference"), function(ref) {
-          map_chr(ref, function(ref_i) {
+          map2_chr(ref, PASS, function(ref_i, pass_i) {
             parse(text = ref_i, keep.source = TRUE) %>%
               getParseData() %>%
               filter(terminal) %>%
               mutate(text = ifelse(token == "SYMBOL",
-                                   paste0(text, "_", PASS),
+                                   paste0(text, "_", pass_i),
                                    text)) %>%
               pull(text) %>%
               paste(collapse = "")


### PR DESCRIPTION
Do not modify `samples$ReporterName`. Ensure references in `samples$ReporterAlias` match those in `references$Reference`. Remove `remove_duplicate_digits` function and associated code, since there are no duplicates within either the PASS1A or PASS1C samples. It is fine if the same ReporterAlias is present in both PASS studies.